### PR TITLE
DDCE-2273: update to Scala 2.12

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,21 +1,20 @@
-import io.gatling.sbt.GatlingPlugin
-
 
 name := "digital-tariffs-operational-performance-tests"
 
 version := "1.0"
 
-scalaVersion := "2.11.11"
+scalaVersion := "2.12.14"
 
-val gatlingVersion = "2.2.5"
+val gatlingVersion = "3.4.2"
 
-libraryDependencies ++= Seq("io.gatling" % "gatling-core" % "2.2.5",
-  "com.github.nscala-time" %% "nscala-time" % "2.22.0",
-  "com.typesafe" % "config" % "1.3.3",
-  "com.typesafe.play" % "play-json_2.11" % "2.4.3",
-  "io.gatling.highcharts" % "gatling-charts-highcharts" % gatlingVersion,
-  "io.gatling" % "gatling-test-framework" % gatlingVersion,
-  "uk.gov.hmrc" %% "performance-test-runner" % "3.3.0"
+
+libraryDependencies ++= Seq(
+  "com.github.nscala-time" %% "nscala-time"               % "2.28.0",
+  "com.typesafe"           %  "config"                    % "1.3.3",
+  "com.typesafe.play"      %% "play-json"                 % "2.6.10",
+  "io.gatling.highcharts"  %  "gatling-charts-highcharts" % gatlingVersion % Test,
+  "io.gatling"             %  "gatling-test-framework"    % gatlingVersion % Test,
+  "uk.gov.hmrc"            %% "performance-test-runner"   % "4.11.0"
 )
 
 enablePlugins(GatlingPlugin)

--- a/build.sbt
+++ b/build.sbt
@@ -1,25 +1,15 @@
 
-name := "digital-tariffs-operational-performance-tests"
-
-version := "1.0"
-
-scalaVersion := "2.12.14"
-
-val gatlingVersion = "3.4.2"
-
-
-libraryDependencies ++= Seq(
-  "com.github.nscala-time" %% "nscala-time"               % "2.28.0",
-  "com.typesafe"           %  "config"                    % "1.3.3",
-  "com.typesafe.play"      %% "play-json"                 % "2.6.10",
-  "io.gatling.highcharts"  %  "gatling-charts-highcharts" % gatlingVersion % Test,
-  "io.gatling"             %  "gatling-test-framework"    % gatlingVersion % Test,
-  "uk.gov.hmrc"            %% "performance-test-runner"   % "4.11.0"
-)
-
-enablePlugins(GatlingPlugin)
-
-parallelExecution in Test := false
-
-resolvers += "hmrc-releases" at "https://artefacts.tax.service.gov.uk/artifactory/hmrc-releases/"
-
+lazy val root = (project in file("."))
+  .enablePlugins(GatlingPlugin)
+  .settings(
+    name := "digital-tariffs-operational-performance-tests",
+    version := "0.1.0-SNAPSHOT",
+    scalaVersion := "2.12.14",
+    //implicitConversions & postfixOps are Gatling recommended -language settings
+    scalacOptions ++= Seq("-feature", "-language:implicitConversions", "-language:postfixOps"),
+    // Enabling sbt-auto-build plugin provides DefaultBuildSettings with default `testOptions` from `sbt-settings` plugin.
+    // These testOptions are not compatible with `sbt gatling:test`. So we have to override testOptions here.
+    testOptions in Test := Seq.empty,
+    libraryDependencies ++= Dependencies.test,
+    resolvers += "hmrc-releases" at "https://artefacts.tax.service.gov.uk/artifactory/hmrc-releases/"
+  )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,0 +1,15 @@
+import sbt._
+
+object Dependencies {
+
+  private val gatlingVersion = "3.4.2"
+
+  val test = Seq(
+    "com.github.nscala-time" %% "nscala-time"               % "2.28.0" % Test,
+    "com.typesafe"           %  "config"                    % "1.3.3" % Test,
+    "com.typesafe.play"      %% "play-json"                 % "2.6.10" % Test,
+    "io.gatling.highcharts"  %  "gatling-charts-highcharts" % gatlingVersion % Test,
+    "io.gatling"             %  "gatling-test-framework"    % gatlingVersion % Test,
+    "uk.gov.hmrc"            %% "performance-test-runner"   % "4.11.0" % Test
+  )
+}

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.17
+sbt.version=1.4.9

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,8 @@
 resolvers += "HMRC-open-artefacts-maven" at "https://open.artefacts.tax.service.gov.uk/maven2"
 resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(Resolver.ivyStylePatterns)
 
-addSbtPlugin("io.gatling" % "gatling-sbt" % "2.1.7")
-addSbtPlugin("uk.gov.hmrc" % "sbt-settings" % "3.9.0")
+addSbtPlugin("io.gatling" % "gatling-sbt" % "3.2.1")
+addSbtPlugin("uk.gov.hmrc" % "sbt-settings" % "4.9.0")
 addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.15.0")
+
+addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.6.0")

--- a/src/test/scala/uk/gov/hmrc/perftests/digitaltariffs/DigitalTariffsPerformanceTestRunner.scala
+++ b/src/test/scala/uk/gov/hmrc/perftests/digitaltariffs/DigitalTariffsPerformanceTestRunner.scala
@@ -1,7 +1,7 @@
 package uk.gov.hmrc.perftests.digitaltariffs
 
 import io.gatling.core.Predef._
-import io.gatling.core.controller.inject.InjectionStep
+import io.gatling.core.controller.inject.open.OpenInjectionStep
 import io.gatling.http.Predef.http
 import io.gatling.http.protocol.HttpProtocolBuilder
 import uk.gov.hmrc.performance.conf.ServicesConfiguration
@@ -15,7 +15,7 @@ trait DigitalTariffsPerformanceTestRunner extends PerformanceTestRunner with Ser
     http
       .userAgentHeader("DigitalTariffs-PerformanceTests")
       .connectionHeader("close")
-      .baseURL(url)
+      .baseUrl(url)
   }
 
   protected val adminBaseUrl = "https://admin.staging.tax.service.gov.uk"
@@ -35,7 +35,7 @@ trait DigitalTariffsPerformanceTestRunner extends PerformanceTestRunner with Ser
   protected val rampInterval = 1.minute // 5.seconds
   protected val mainInterval = 8.minutes // 15.seconds
 
-  protected def simulationSteps: Seq[InjectionStep] =
+  protected def simulationSteps: Seq[OpenInjectionStep] =
     Seq(
       rampUsersPerSec(0).to(rate).during(rampInterval), // growth
       constantUsersPerSec(rate).during(mainInterval), // constant


### PR DESCRIPTION
bump gatling and other deps
Jenkins performance run: 
https://performance.tools.staging.tax.service.gov.uk/view/Digital%20Tariffs/job/digital-tariffs-operational-performance-tests/21/
(failure against staging environment, likely related to db issues)